### PR TITLE
Updated dependencies to work with Laravel 11. Updated (single) carbon use case

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,12 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "php": ">=7.2.0",
-        "illuminate/auth": ">=6.0.0",
-        "illuminate/routing": ">=6.0.0",
-        "illuminate/support": ">=6.0.0",
-        "illuminate/contracts": ">=6.0.0",
-        "nesbot/carbon": "^2.0"
+        "php": ">=8.2.0",
+        "illuminate/auth": ">=11.0.0",
+        "illuminate/routing": ">=11.0.0",
+        "illuminate/support": ">=11.0.0",
+        "illuminate/contracts": ">=11.0.0",
+        "nesbot/carbon": "^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Services/RoleService.php
+++ b/src/Services/RoleService.php
@@ -70,7 +70,7 @@ class RoleService
                 $this->cache->add(
                     $cacheKey,
                     json_encode($authorities),
-                    Carbon::now()->addSeconds(config('role.cache_time_seconds'))
+                    Carbon::now()->addSeconds((int) config('role.cache_time_seconds'))
                 );
             }
             return collect($authorities);


### PR DESCRIPTION
- php version bumped to ^8.2
- Illuminate packages bumped to 11x
- Carbon increased from 2.x -> 3.x

Tested this against our own repo with the package already implemented, didnt seem to bust pages or rolegroupstableseeder call. Did not test base migrations.